### PR TITLE
enhance typehint support for older versions of Python

### DIFF
--- a/dependent_bterms/dependent_variable_ring.py
+++ b/dependent_bterms/dependent_variable_ring.py
@@ -16,6 +16,8 @@ TESTS::
 
 """
 
+from __future__ import annotations
+
 from sage.symbolic.ring import SR
 
 from sage.rings.asymptotic.asymptotic_ring import AsymptoticRing, AsymptoticExpansion

--- a/dependent_bterms/structures.py
+++ b/dependent_bterms/structures.py
@@ -16,6 +16,9 @@ TESTS::
 
 """
 
+from __future__ import annotations
+
+
 from sage.functions.other import ceil
 from sage.rings.asymptotic.asymptotic_ring import AsymptoticRing
 from sage.rings.asymptotic.term_monoid import (

--- a/dependent_bterms/utils.py
+++ b/dependent_bterms/utils.py
@@ -14,6 +14,9 @@ TESTS::
 
 """
 
+from __future__ import annotations
+
+
 from sage.arith.srange import srange
 from sage.ext.fast_callable import fast_callable
 from sage.functions.other import ceil


### PR DESCRIPTION
... with SageMath 10.5, my local system used a base version of Python 3.9, for which the type hint operations used in the package need the backwards compatibilty port (`from __future__ import annotations` ...).